### PR TITLE
Add Imsak and Duha times for Ramadan (v2.1.0) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A lightweight Arduino library for calculating Islamic prayer times based on multiple calculation methods. Supports various regions and methods such as MWL, ISNA, Umm al-Qura, Egyptian, Karachi, Tehran, and Jafari.
 
+**v2.1.0 Highlights:** Added Imsak (fasting start) and Duha (forenoon prayer) times with configurable offsets and angles.
+
 **v2.0 Highlights:** Input validation, error handling, high-latitude polar region support, and automatic smart defaults.
 
 ## Quick Start
@@ -48,8 +50,10 @@ if (result.valid) {
   - **Institute of Geophysics, University of Tehran**
   - **Jafari (Shia Ithna Ashari)**
   - Plus 15+ additional methods for worldwide coverage
-- Computes all **five daily prayer times** + **sunrise**:
+- Computes all **five daily prayer times** + **sunrise**, **Imsak**, and **Duha**:
   - **Fajr**, **Sunrise**, **Dhuhr**, **Asr**, **Maghrib**, **Isha**
+  - **Imsak** - Time to begin fasting (configurable buffer before Fajr)
+  - **Duha** - Forenoon prayer time (sun elevation angle based)
 - **Input validation** for coordinates (±90° latitude, ±180° longitude) and dates
 - **Error handling** with diagnostic messages for invalid inputs
 - **High-latitude support** (Arctic/Antarctic regions >66.5°) with four adjustment methods:
@@ -70,6 +74,60 @@ if (result.valid) {
    - macOS: `~/Documents/Arduino/libraries`
    - Linux: `~/Arduino/libraries`
 3. Restart the Arduino IDE.
+
+## v2.1 Features (New)
+
+### Imsak Time (Fasting Start)
+Calculate the time to begin fasting with a configurable precautionary buffer (Temkin) before Fajr:
+
+```cpp
+PrayerTimes pt(3.1390, 101.6869, 480);  // Kuala Lumpur
+pt.setCalculationMethod(CalculationMethods::JAKIM);
+
+// Set Imsak offset (minutes before Fajr)
+// Default is 10 min. Malaysian calendars typically use 18-20 min.
+pt.setImsakOffset(18);
+
+PrayerTimesResult result = pt.calculate(1, 3, 2026);
+if (result.valid) {
+    Serial.print("Imsak: ");
+    Serial.println(pt.formatTime12(result.imsak));  // Start fasting
+    Serial.print("Fajr:  ");
+    Serial.println(pt.formatTime12(result.fajr));   // True dawn
+}
+```
+
+### Duha Time (Forenoon Prayer)
+Calculate the forenoon prayer time based on sun elevation angle:
+
+```cpp
+// Set Duha angle (degrees above horizon)
+// Default is 4.5°. JAKIM uses 4°42' (~4.7°), Indonesia uses 3.5°
+pt.setDuhaAngle(4.7);
+
+PrayerTimesResult result = pt.calculate(1, 3, 2026);
+if (result.valid) {
+    Serial.print("Duha: ");
+    Serial.println(pt.formatTime12(result.duha));  // Forenoon prayer
+}
+```
+
+### Legacy API Support
+The legacy API now supports optional Imsak and Duha parameters:
+
+```cpp
+int fajrH, fajrM, imsakH, imsakM, duhaH, duhaM;
+
+pt.calculate(1, 3, 2026,
+             fajrH, fajrM,
+             sunriseH, sunriseM,
+             dhuhrH, dhuhrM,
+             asrH, asrM,
+             maghribH, maghribM,
+             ishaH, ishaM,
+             &imsakH, &imsakM,  // Optional: Imsak output
+             &duhaH, &duhaM);   // Optional: Duha output
+```
 
 ## v2.0 Features & Improvements
 
@@ -145,6 +203,7 @@ The library includes comprehensive examples:
 
 - **Multi-City_Test.ino** - Calculate prayer times for 5 cities worldwide (Montreal, Mumbai, Tokyo, Oslo, Tromsø)
 - **Advanced_Error_Handling.ino** - Demonstrates error handling, validation, and high-latitude adjustments with 7 test cases
+- **Imsak_Duha_Example.ino** - Multi-city test showing Imsak and Duha calculations with regional variations (Malaysia, Turkey, Indonesia, Saudi Arabia, Egypt)
 
 Run these examples to see the library in action and learn best practices.
 

--- a/examples/Imsak_Duha_Example/Imsak_Duha_Example.ino
+++ b/examples/Imsak_Duha_Example/Imsak_Duha_Example.ino
@@ -1,0 +1,203 @@
+/*
+ * Imsak and Duha Prayer Times - Multi-City Example
+ * 
+ * This example demonstrates Imsak (fasting start) and Duha (forenoon) times
+ * across different cities with regional calculation preferences.
+ * 
+ * Imsak: Time to begin fasting (Fajr minus precautionary buffer/Temkin)
+ * Duha: Forenoon prayer time (when sun reaches specific altitude)
+ * 
+ * Hardware: Any Arduino-compatible board
+ * Output: Serial monitor at 9600 baud
+ * 
+ * Author: Adnan Saab
+ * Version: 2.1.0
+ */
+
+#include <Arduino.h>
+#include "PrayerTimes.h"
+
+// Fixed test date for all cities
+static const int DAY   = 1;
+static const int MONTH = 3;
+static const int YEAR  = 2026;
+
+// Helper function to get month name
+const char* getMonthName(int month) {
+  const char* months[] = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+  };
+  if (month >= 1 && month <= 12) {
+    return months[month - 1];
+  }
+  return "Unknown";
+}
+
+// Helper function to format date
+String formatDate(int day, int month, int year) {
+  char buffer[32];
+  sprintf(buffer, "%s %d, %d", getMonthName(month), day, year);
+  return String(buffer);
+}
+
+void printCityWithImsakDuha(
+  const char* label,
+  float lat,
+  float lon,
+  int tzMinutes,
+  const CalculationConfig& method,
+  int imsakOffsetMinutes,
+  float duhaAngle,
+  const char* notes = nullptr
+) {
+  PrayerTimes pt(lat, lon, tzMinutes);
+  
+  if (!pt.isInitialized()) {
+    Serial.print("ERROR: Invalid coordinates for ");
+    Serial.println(label);
+    return;
+  }
+  
+  // Apply high-latitude rule if needed
+  if (pt.isHighLatitude()) {
+    pt.setHighLatitudeRule(MIDDLE_OF_NIGHT);
+  }
+  
+  // Set calculation method and Imsak/Duha parameters
+  pt.setCalculationMethod(method);
+  pt.setImsakOffset(imsakOffsetMinutes);
+  pt.setDuhaAngle(duhaAngle);
+
+  PrayerTimesResult result = pt.calculate(DAY, MONTH, YEAR);
+
+  if (!result.valid) {
+    Serial.print("ERROR: Calculation failed for ");
+    Serial.println(label);
+    return;
+  }
+
+  Serial.println();
+  Serial.print("=== "); Serial.println(label);
+  
+  if (notes != nullptr) {
+    Serial.print("    "); Serial.println(notes);
+  }
+  
+  Serial.print("    Method: "); Serial.println(method.name);
+  Serial.print("    Imsak Offset: "); Serial.print(imsakOffsetMinutes); Serial.println(" min before Fajr");
+  Serial.print("    Duha Angle: "); Serial.print(duhaAngle); Serial.println("° above horizon");
+  Serial.println();
+  
+  int hour, minute;
+  
+  // Imsak
+  pt.minutesToTime(result.imsak, hour, minute);
+  Serial.print("  Imsak   (Fast Start)  : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  // Fajr
+  pt.minutesToTime(result.fajr, hour, minute);
+  Serial.print("  Fajr    (True Dawn)   : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  // Sunrise
+  pt.minutesToTime(result.sunrise, hour, minute);
+  Serial.print("  Sunrise               : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  // Duha
+  pt.minutesToTime(result.duha, hour, minute);
+  Serial.print("  Duha    (Forenoon)    : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  // Dhuhr
+  pt.minutesToTime(result.dhuhr, hour, minute);
+  Serial.print("  Dhuhr                 : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  // Maghrib
+  pt.minutesToTime(result.maghrib, hour, minute);
+  Serial.print("  Maghrib (Fast End)    : ");
+  Serial.println(pt.formatTime12(hour, minute));
+  
+  if (pt.isHighLatitude()) {
+    Serial.println();
+    Serial.println("  * High-latitude adjustments applied");
+  }
+}
+
+void setup() {
+  Serial.begin(9600);
+  delay(2000);
+
+  Serial.println("=== PrayerTimes v2.1 - Imsak & Duha Multi-City Test ===");
+  Serial.print("Date: ");
+  Serial.println(formatDate(DAY, MONTH, YEAR));
+  Serial.println();
+  Serial.println("Imsak: Time to begin fasting (configurable buffer before Fajr)");
+  Serial.println("Duha:  Forenoon prayer time (sun elevation angle based)");
+  Serial.println("============================================================");
+
+  // Malaysia (JAKIM) - Uses 18-20 min Temkin, 4.7° Duha
+  printCityWithImsakDuha(
+    "Kuala Lumpur, Malaysia",
+    3.1390, 101.6869, 480,
+    CalculationMethods::JAKIM,
+    18,      // 18 minutes Temkin
+    4.7,     // 4°42' as used by JAKIM
+    "Islamic authority: JAKIM"
+  );
+
+  // Turkey (Diyanet) - Uses 10-12 min Temkin, 4.5° Duha
+  printCityWithImsakDuha(
+    "Istanbul, Turkey",
+    41.0082, 28.9784, 180,
+    CalculationMethods::TURKEY,
+    12,      // 12 minutes Temkin
+    4.5,
+    "Islamic authority: Diyanet"
+  );
+
+  // Indonesia - Uses 10 min, 3.5° Duha
+  printCityWithImsakDuha(
+    "Jakarta, Indonesia",
+    -6.2088, 106.8456, 420,
+    CalculationMethods::INDONESIA,
+    10,
+    3.5,
+    "Regional: 3.5° Duha angle"
+  );
+
+  // Saudi Arabia (Umm al-Qura) - Default 10 min, 5.0° Duha
+  printCityWithImsakDuha(
+    "Makkah, Saudi Arabia",
+    21.4225, 39.8262, 180,
+    CalculationMethods::MAKKAH,
+    10,
+    5.0,
+    "Umm al-Qura method"
+  );
+
+  // Egypt - Uses 10 min, 4.5° Duha
+  printCityWithImsakDuha(
+    "Cairo, Egypt",
+    30.0444, 31.2357, 120,
+    CalculationMethods::EGYPT,
+    10,
+    4.5,
+    "Egyptian General Authority"
+  );
+
+  Serial.println();
+  Serial.println("============================================================");
+  Serial.println("Notes:");
+  Serial.println("- Imsak offset is configurable (default: 10 minutes)");
+  Serial.println("- Duha angle varies by region (3.5° - 5.0° typical range)");
+  Serial.println("- Use setImsakOffset(minutes) and setDuhaAngle(degrees)");
+  Serial.println("============================================================");
+  Serial.println();
+  Serial.println("=== End of Test ===");
+}
+
+void loop() {}

--- a/keywords.txt
+++ b/keywords.txt
@@ -10,7 +10,7 @@ PrayerTimes	KEYWORD1
 PrayerTimesResult	KEYWORD1
 CalculationConfig	KEYWORD1
 AsrMethod	KEYWORD1
-HighLatitudeRule	KEYWORD1	PrayerTimes
+HighLatitudeRule	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -29,6 +29,8 @@ minutesToTime	KEYWORD2
 isInitialized	KEYWORD2
 isHighLatitude	KEYWORD2
 getLatitude	KEYWORD2
+setImsakOffset	KEYWORD2
+setDuhaAngle	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
@@ -36,8 +38,8 @@ getLatitude	KEYWORD2
 
 MWL	LITERAL1
 ISNA	LITERAL1
-UmmAlQura	LITERAL1
-Egyptian	LITERAL1
+MAKKAH	LITERAL1
+EGYPT	LITERAL1
 Karachi	LITERAL1
 Tehran	LITERAL1
 Jafari	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=PrayerTimes
-version=2.0.1
+version=2.1.0
 author=Adnan Saab
 maintainer=Adnan Saab <adnan.9821@gmail.com>
 sentence=A lightweight Arduino library for calculating Islamic prayer times based on multiple methods.
-paragraph=Supports 20+ calculation methods including MWL, ISNA, Umm al-Qura, Egyptian, Karachi, Tehran, and Jafari. Provides Fajr, Sunrise, Dhuhr, Asr, Maghrib, and Isha calculations with input validation, error handling, high-latitude polar region support, and DST offsets.
+paragraph=Supports 20+ calculation methods including MWL, ISNA, Umm al-Qura, Egyptian, Karachi, Tehran, and Jafari. Provides Fajr, Sunrise, Dhuhr, Asr, Maghrib, Isha, Imsak (fasting start), and Duha (forenoon) calculations with input validation, error handling, high-latitude polar region support, and DST offsets.
 category=Timing
 url=https://github.com/a-saab/PrayerTimes
 architectures=*

--- a/src/PrayerTimes.cpp
+++ b/src/PrayerTimes.cpp
@@ -1,8 +1,16 @@
 /*
- * PrayerTimes Library v2.0 - Implementation
+ * PrayerTimes Library v2.1 - Implementation
  * 
  * Original Author: Adnan Saab (https://github.com/a-saab)
  * Created: February 2025
+ * 
+ * Astronomical calculations based on:
+ * - NOAA solar calculation formulas
+ * - Islamic astronomy tradition (Ibn Yunus, Ottoman calculations)
+ * - Modern authoritative sources (PrayTimes.org, Moonsighting.com)
+ * 
+ * Imsak calculation: Fajr minus configurable buffer (Temkin tradition)
+ * Duha calculation: Sun altitude angle (default 4.5° above horizon)
  */
 
 #include "PrayerTimes.h"
@@ -22,6 +30,8 @@ PrayerTimes::PrayerTimes(float latitude, float longitude, int timezoneOffsetMinu
       _fajrAngle(18.0), _ishaAngle(17.0), 
       _asrMethod(SHAFII), _highLatRule(NONE),
       _ishaIsInterval(false), _ishaMinutes(0),
+      _imsakOffsetMinutes(10),  // Default: 10 minutes before Fajr
+      _duhaAngle(4.5),           // Default: 4.5° above horizon for Duha
       _initialized(false)
 {
     // Validate input coordinates
@@ -60,6 +70,14 @@ void PrayerTimes::setAdjustments(int adjFajr, int adjSunrise, int adjDhuhr,
     _adjAsr = adjAsr;
     _adjMaghrib = adjMaghrib;
     _adjIsha = adjIsha;
+}
+
+void PrayerTimes::setImsakOffset(int minutesBeforeFajr) {
+    _imsakOffsetMinutes = minutesBeforeFajr;
+}
+
+void PrayerTimes::setDuhaAngle(float degreesAboveHorizon) {
+    _duhaAngle = degreesAboveHorizon;
 }
 
 float PrayerTimes::deg2rad(float degrees) {
@@ -255,6 +273,11 @@ PrayerTimesResult PrayerTimes::calculateWithOffset(int day, int month, int year,
     // Apply high-latitude adjustments if needed
     applyHighLatitudeAdjustments(result, solarDec);
     
+    // Calculate Imsak (buffer before Fajr) and Duha (angle-based after sunrise)
+    result.imsak = normalizeTime(result.fajr - _imsakOffsetMinutes);
+    // Duha: when sun reaches specified altitude above horizon (astronomical calculation)
+    result.duha = calculateTimeForAngle(_duhaAngle, solarNoon, solarDec, true);
+    
     // Now apply ALL time offsets at once (manual adjustments + DST)
     result.fajr = normalizeTime(result.fajr + _adjFajr + dstMinutes);
     result.sunrise = normalizeTime(result.sunrise + _adjSunrise + dstMinutes);
@@ -262,6 +285,8 @@ PrayerTimesResult PrayerTimes::calculateWithOffset(int day, int month, int year,
     result.asr = normalizeTime(result.asr + _adjAsr + dstMinutes);
     result.maghrib = normalizeTime(result.maghrib + _adjMaghrib + dstMinutes);
     result.isha = normalizeTime(result.isha + _adjIsha + dstMinutes);
+    result.imsak = normalizeTime(result.imsak + _adjFajr + dstMinutes);  // Imsak follows Fajr adjustment
+    result.duha = normalizeTime(result.duha + _adjSunrise + dstMinutes); // Duha follows Sunrise adjustment
     
     result.valid = true;
     result.errorMessage = nullptr;
@@ -275,7 +300,9 @@ void PrayerTimes::calculate(int day, int month, int year,
                              int &dhuhrHour, int &dhuhrMinute,
                              int &asrHour, int &asrMinute,
                              int &maghribHour, int &maghribMinute,
-                             int &ishaHour, int &ishaMinute) {
+                             int &ishaHour, int &ishaMinute,
+                             int *imsakHour, int *imsakMinute,
+                             int *duhaHour, int *duhaMinute) {
     PrayerTimesResult result = calculate(day, month, year);
     
     minutesToTime(result.fajr, fajrHour, fajrMinute);
@@ -284,6 +311,14 @@ void PrayerTimes::calculate(int day, int month, int year,
     minutesToTime(result.asr, asrHour, asrMinute);
     minutesToTime(result.maghrib, maghribHour, maghribMinute);
     minutesToTime(result.isha, ishaHour, ishaMinute);
+    
+    // Optional new parameters - only set if pointers are provided
+    if (imsakHour != nullptr && imsakMinute != nullptr) {
+        minutesToTime(result.imsak, *imsakHour, *imsakMinute);
+    }
+    if (duhaHour != nullptr && duhaMinute != nullptr) {
+        minutesToTime(result.duha, *duhaHour, *duhaMinute);
+    }
 }
 
 void PrayerTimes::minutesToTime(float minutes, int &hour, int &minute) {

--- a/src/PrayerTimes.h
+++ b/src/PrayerTimes.h
@@ -1,5 +1,5 @@
 /*
- * PrayerTimes Library v2.0
+ * PrayerTimes Library v2.1
  * 
  * Original Author: Adnan Saab (https://github.com/a-saab)
  * Created: February 2025
@@ -13,6 +13,19 @@
  * - Extensible calculation method system
  * - High-latitude handling
  * - Defensive math for embedded systems
+ * 
+ * v2.1 Additions:
+ * - Imsak time (with configurable Temkin/precautionary buffer)
+ * - Duha/Ishraq time (angle-based astronomical calculation)
+ * 
+ * Calculation References:
+ * - Fajr/Isha: Based on sun depression angles from major Islamic authorities
+ *   (MWL: -18°, ISNA: -15°, Egypt: -19.5°, Umm al-Qura: interval-based, etc.)
+ * - Imsak: Fajr time minus precautionary buffer (default 10 min, "Temkin")
+ *   Used by Turkish Religious Affairs, Egyptian General Authority
+ * - Duha: Sun elevation angle above horizon (default 4.5°, range 4°-6°)
+ *   Based on Malaysian JAKIM (4.7°), Indonesian (3.5°), and general astronomy
+ *   "Spear's height" ~4°15' corresponds to ~16-20 minutes after sunrise
  */
 
 #ifndef PRAYERTIMES_H
@@ -80,10 +93,13 @@ struct PrayerTimesResult {
     float asr;
     float maghrib;
     float isha;
-    bool valid;  // False if calculation failed (e.g., extreme latitude, invalid input)
+    float imsak;  // Time to start fasting (before Fajr)
+    float duha;   // Forenoon prayer time (after sunrise)
+    bool valid;   // False if calculation failed (e.g., extreme latitude, invalid input)
     const char* errorMessage;  // Diagnostic message if valid=false
     
     PrayerTimesResult() : fajr(0), sunrise(0), dhuhr(0), asr(0), maghrib(0), isha(0), 
+                          imsak(0), duha(0),
                           valid(false), errorMessage(nullptr) {}
 };
 
@@ -123,6 +139,16 @@ public:
     // Set manual adjustments (in minutes) for fine-tuning
     void setAdjustments(int adjFajr, int adjSunrise, int adjDhuhr, int adjAsr, int adjMaghrib, int adjIsha);
     
+    // Set Imsak offset (minutes before Fajr, default: 10)
+    // This represents the precautionary buffer (Temkin) used by many authorities
+    // to ensure fasting begins before Fajr al-Sadiq (true dawn)
+    void setImsakOffset(int minutesBeforeFajr);
+    
+    // Set Duha calculation using solar altitude angle (degrees above horizon, default: 4.5°)
+    // Based on research: Malaysia uses 4°42', Indonesia uses 3°30', general range is 4°-6°
+    // Default 4.5° represents the "spear's height" (~16-20 minutes after sunrise)
+    void setDuhaAngle(float degreesAboveHorizon);
+    
     // Calculate prayer times for a given date
     // Returns a structure with all times in minutes since midnight
     PrayerTimesResult calculate(int day, int month, int year);
@@ -132,13 +158,16 @@ public:
     PrayerTimesResult calculateWithOffset(int day, int month, int year, int dstMinutes);
     
     // Legacy API compatibility (v1.x interface)
+    // New: Optional imsak and duha parameters added at the end for backward compatibility
     void calculate(int day, int month, int year,
                    int &fajrHour, int &fajrMinute,
                    int &sunriseHour, int &sunriseMinute,
                    int &dhuhrHour, int &dhuhrMinute,
                    int &asrHour, int &asrMinute,
                    int &maghribHour, int &maghribMinute,
-                   int &ishaHour, int &ishaMinute);
+                   int &ishaHour, int &ishaMinute,
+                   int *imsakHour = nullptr, int *imsakMinute = nullptr,
+                   int *duhaHour = nullptr, int *duhaMinute = nullptr);
     
     // Utility functions for time formatting
     static String formatTime12(int hour, int minute);
@@ -162,6 +191,10 @@ private:
     
     // Manual adjustments
     int _adjFajr, _adjSunrise, _adjDhuhr, _adjAsr, _adjMaghrib, _adjIsha;
+    
+    // Imsak and Duha calculation parameters
+    int _imsakOffsetMinutes;   // Minutes before Fajr (default: 10)
+    float _duhaAngle;          // Solar altitude for Duha (default: 4.5° above horizon)
     
     // Core astronomical calculations
     float deg2rad(float degrees);


### PR DESCRIPTION
This PR adds support for **Imsak** (fasting start) and **Duha** (forenoon prayer) times.

## Changes:
- Added `imsak` and `duha` fields to `PrayerTimesResult` struct
- Added `setImsakOffset(minutes)` - configurable buffer before Fajr (default: 10 min)
- Added `setDuhaAngle(degrees)` - sun elevation angle (default: 4.5°)
- Legacy API updated with optional Imsak/Duha output parameters
- New example: `Imsak_Duha_Example.ino` (multi-city test with regional variations)
- Updated README with v2.1.0 features
- Fixed keywords.txt constants

Closes #2